### PR TITLE
동의한 후보들의 이메일 오류 제거

### DIFF
--- a/components/Ask/index.js
+++ b/components/Ask/index.js
@@ -9,7 +9,7 @@ import style from './index.styl'
 
 const SentResult = ({candidate}) => {
     const [agreed, setAgreed] = React.useState('')
-    const [showEmail, setShowEmail] = React.useState('')
+    const [hasEmail, setHasEmail] = React.useState('')
 
     React.useEffect(() => {
         const fetchAgreed = async () => {
@@ -26,8 +26,9 @@ const SentResult = ({candidate}) => {
     React.useEffect(() => {
         const fetchEmail = async () => {
             const data = await import(`public/candidates/${candidate.id}.json`)
+            console.log(data)
             if (data.hasEmail || agreed === '동의') {
-                setShowEmail(true)
+                setHasEmail(true)
             }
         }
         fetchEmail()
@@ -41,7 +42,7 @@ const SentResult = ({candidate}) => {
                 <>{agreed}</>
             </td>
             <td className={style.contact}>
-                {showEmail ? '' : '(대기중. 이메일오류)'}
+                {hasEmail ? '' : '(대기중. 이메일오류)'}
             </td>
         </>
     )


### PR DESCRIPTION
- 기존의 `agreed`와 이메일 오류 여부를 보여주는 `showEmail`을 만들어 `<SentResult />`으로 합쳤습니다.
- SentResult 안에 agreed와 showEmail 2의 상태를 만들고 useEffect도 2개를 만들었는데 불필요할까요? (useEffect 함수는 state를 하나만 관리하는 것이 좋다고 생각해서 그렇게 했어요)